### PR TITLE
Enable FrictionlessData's goodtables.io integration 

### DIFF
--- a/DataPackages/Goal/1/datapackage.json
+++ b/DataPackages/Goal/1/datapackage.json
@@ -1,5 +1,5 @@
  {
-                    "name": "Goal 1",
+                    "name": "goal-1",
                     "title": "End poverty in all its forms everywhere",
                     "description": "Goal 1 calls for an end to poverty in all its manifestations, including extreme poverty, over the next 15 years. All people everywhere, including the poorest and most vulnerable, should enjoy a basic standard of living and social protection benefits.",
                     "homepage": "https://unstats.un.org/sdgs",

--- a/DataPackages/Goal/1/datapackage.json
+++ b/DataPackages/Goal/1/datapackage.json
@@ -14,7 +14,6 @@
                             "name": "dimensionvalues",
                             "path": "dimensionvalues.csv",
                             "encoding": "ISO-8859-1",
-                            "csvDialect": {"skipInitialSpace": true},
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Dimension", "type": "string" }, { "name": "Value", "type": "string" }, { "name": "Description", "type": "string" }] }
@@ -22,7 +21,6 @@
                             "name": "geography",
                             "path": "geography.csv",
                             "encoding": "ISO-8859-1",
-                            "csvDialect": {"skipInitialSpace": true},
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Lineage", "type": "string" }, { "name": "ParentGeoAreaName", "type": "string" }, { "name": "ParentGeoAreaCode", "type": "string" }, { "name": "GeoAreaName", "type": "string" }, { "name": "GeoAreacode", "type": "string" }, { "name": "Type", "type": "string" }] }

--- a/DataPackages/Goal/1/datapackage.json
+++ b/DataPackages/Goal/1/datapackage.json
@@ -6,18 +6,21 @@
                     "resources": [{
                             "name": "data",
                             "path": "data.csv",
+                            "encoding": "ISO-8859-1",
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Goal", "type": "string" }, { "name": "Target", "type": "string" }, { "name": "Indicator", "type": "string" }, { "name": "SeriesCode", "type": "string" }, { "name": "SeriesDescription", "type": "string" }, { "name": "GeoAreaName", "type": "string" }, { "name": "TimePeriod", "type": "string" }, { "name": "Value", "type": "string" }, { "name": "Time_Detail", "type": "string" }, { "name": "Source", "type": "string" }, { "name": "FootNote", "type": "string" }, { "name": "[Age]", "type": "string" }, { "name": "[Hazard type]", "type": "string" }, { "name": "[Location]", "type": "string" }, { "name": "[Sex]", "type": "string" }, { "name": "[Units]", "type": "string" }] }
                             }, {
                             "name": "dimensionvalues",
                             "path": "dimensionvalues.csv",
+                            "encoding": "ISO-8859-1",
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Dimension", "type": "string" }, { "name": "Value", "type": "string" }, { "name": "Description", "type": "string" }] }
                             }, {
                             "name": "geography",
                             "path": "geography.csv",
+                            "encoding": "ISO-8859-1",
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Lineage", "type": "string" }, { "name": "ParentGeoAreaName", "type": "string" }, { "name": "ParentGeoAreaCode", "type": "string" }, { "name": "GeoAreaName", "type": "string" }, { "name": "GeoAreacode", "type": "string" }, { "name": "Type", "type": "string" }] }

--- a/DataPackages/Goal/1/datapackage.json
+++ b/DataPackages/Goal/1/datapackage.json
@@ -14,6 +14,7 @@
                             "name": "dimensionvalues",
                             "path": "dimensionvalues.csv",
                             "encoding": "ISO-8859-1",
+                            "csvDialect": {"skipInitialSpace": true},
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Dimension", "type": "string" }, { "name": "Value", "type": "string" }, { "name": "Description", "type": "string" }] }
@@ -21,6 +22,7 @@
                             "name": "geography",
                             "path": "geography.csv",
                             "encoding": "ISO-8859-1",
+                            "csvDialect": {"skipInitialSpace": true},
                             "format": "csv",
                             "mediatype": "text/csv",
                             "schema": { "fields": [{ "name": "Lineage", "type": "string" }, { "name": "ParentGeoAreaName", "type": "string" }, { "name": "ParentGeoAreaCode", "type": "string" }, { "name": "GeoAreaName", "type": "string" }, { "name": "GeoAreacode", "type": "string" }, { "name": "Type", "type": "string" }] }

--- a/DataPackages/Goal/1/dimensionvalues.csv
+++ b/DataPackages/Goal/1/dimensionvalues.csv
@@ -1,4 +1,4 @@
-Dimension, Value, Description
+Dimension,Value,Description
 "Age","<1M","under 1 month old"
 "Age","<1Y","under 1 year old"
 "Age","<5Y","under 5 years old"

--- a/DataPackages/Goal/1/geography.csv
+++ b/DataPackages/Goal/1/geography.csv
@@ -1,4 +1,4 @@
-Lineage, ParentGeoAreaName, ParentGeoAreaCode, GeoAreaName, GeoAreacode, Type
+Lineage,ParentGeoAreaName,ParentGeoAreaCode,GeoAreaName,GeoAreacode,Type
 "World (1)",,,"World","1","Region"
 "World (1) -- Antarctica (10)","World","1","Antarctica","10","Country"
 "World (1) -- Africa (2)","World","1","Africa","2","Region"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ## SDG Repositiry
 
-This is the collaborative space for our tools and data around the SDG indicators. 
+[![goodtables.io](https://goodtables.io/badge/github/roll/SDG.svg)](https://goodtables.io/github/roll/SDG)
+
+This is the collaborative space for our tools and data around the SDG indicators.
 
 ## Purpose
 
-Data requirements for the 2030 Agenda for Sustainable Development, with its 17 Sustainable Development Goals (SDGs), 169 targets and over 230 global indicators, present an unprecedented challenge for both national statistical systems and the international statistical community. In the UN General Assembly Resolution 70/1, Member States stressed that follow-up and review processes at all levels would be based on high-quality, accessible, timely, reliable data, disaggregated by income, sex, age, race, ethnicity, migration status, disability and geographic location and other characteristics. Also, both GA resolution 70/1 and Statistical Commission decision 47/101(l) stress that the compilation of the global SDG indicators is to be based on data produced by national statistical systems. 
+Data requirements for the 2030 Agenda for Sustainable Development, with its 17 Sustainable Development Goals (SDGs), 169 targets and over 230 global indicators, present an unprecedented challenge for both national statistical systems and the international statistical community. In the UN General Assembly Resolution 70/1, Member States stressed that follow-up and review processes at all levels would be based on high-quality, accessible, timely, reliable data, disaggregated by income, sex, age, race, ethnicity, migration status, disability and geographic location and other characteristics. Also, both GA resolution 70/1 and Statistical Commission decision 47/101(l) stress that the compilation of the global SDG indicators is to be based on data produced by national statistical systems.

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -4,4 +4,4 @@ datapackages:
 settings:
   row_limit: 100000
   checks:
-    duplicate_rows: false
+    duplicate-row: false

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,5 +1,7 @@
 datapackages:
   - DataPackages/Goal/1/datapackage.json
+  # - DataPackages/Goal/2/datapackage.json
+  # - etc
 
 settings:
   row_limit: 100000

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,0 +1,2 @@
+datapackages:
+  - DataPackages/Goal/1/datapackage.json

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,2 +1,5 @@
 datapackages:
   - DataPackages/Goal/1/datapackage.json
+
+settings:
+  row_limit: 10000

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,5 +1,7 @@
 datapackages:
-  - DataPackages/Goal/1/datapackage.json
+  - source: DataPackages/Goal/1/datapackage.json
+    skip_checks:
+      - duplicate_rows
 
 settings:
   row_limit: 100000

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,7 +1,7 @@
 datapackages:
-  - source: DataPackages/Goal/1/datapackage.json
-    skip_checks:
-      - duplicate_rows
+  - DataPackages/Goal/1/datapackage.json
 
 settings:
   row_limit: 100000
+  checks:
+    duplicate_rows: false

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -2,4 +2,4 @@ datapackages:
   - DataPackages/Goal/1/datapackage.json
 
 settings:
-  row_limit: 10000
+  row_limit: 100000


### PR DESCRIPTION
@jobarratt
@gonzalezmorales 
In continuation of the email discussion about the SDG data packages. Regarding this project, I found as very applicable to set up our new-brand continuous data validation service https://goodtables.io for this repository. It will help to achieve metadata validity along with an actual data quality.

The goodtables.io validates every change in a github repo and reports about data and metadata quality problems. In this PR I show how it helped me to update `Goal/1` data package (see PR comments - will be available in a few minutes after PR creation).

Validation status of my fork: 
- https://github.com/roll/SDG (github)
- https://goodtables.io/github/roll/SDG/jobs/9 (goodtables.io)

This PR contains all required changes to the repo for `Goal/1` validation (other data packages should be added to `goodtables.yml`). So it only misses the step of repo activation on the https://goodtables.io:
- https://docs.goodtables.io/ (comprehensive docs including the "how to set up the repo" section)

Also, we built other tools helping to work with data packages (both are more useful for one-time operations):
- https://frictionlessdata.io/field-guide/well-packaged-datasets/ (Data Package Creator)
- https://try.goodtables.io/?source=https%3A%2F%2Fraw.githubusercontent.com%2Froll%2FSDG%2Fmaster%2FDataPackages%2FGoal%2F1%2Fdatapackage.json&preset=datapackage&checks%5Bduplicate-row%5D=false&apiJobId=f6d49dca-6fac-11e8-a044-0a580a240208 (try.goodtables.io using `Goal/1` example)